### PR TITLE
Drop database on push to main

### DIFF
--- a/.github/workflows/deploy-db.yml
+++ b/.github/workflows/deploy-db.yml
@@ -68,6 +68,32 @@ jobs:
           echo "postgres-db=${{ steps.normalize-name.outputs.db-name }}" >> "$GITHUB_OUTPUT"
           echo "postgres-user=stitch_app" >> "$GITHUB_OUTPUT"
 
+      - name: Drop database on push to main
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+        env:
+          DB_NAME: ${{ steps.normalize-name.outputs.db-name }}
+        run: |
+          set -euo pipefail
+
+          echo "Target server: $PGHOST"
+          echo "Resetting DB: $DB_NAME"
+
+          EXISTS=$(psql -X -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" || true)
+
+          if [ "$EXISTS" = "1" ]; then
+            psql -X -v ON_ERROR_STOP=1 -c "
+              SELECT pg_terminate_backend(pid)
+              FROM pg_stat_activity
+              WHERE datname = '${DB_NAME}'
+                AND pid <> pg_backend_pid();
+            "
+
+            psql -X -v ON_ERROR_STOP=1 -c "DROP DATABASE \"${DB_NAME}\";"
+            echo "Database '$DB_NAME' dropped."
+          else
+            echo "Database '$DB_NAME' does not exist. Nothing to drop."
+          fi
+
       - name: Create database if it doesn't exist
         env:
           DB_NAME: ${{ steps.normalize-name.outputs.db-name }}


### PR DESCRIPTION
This treats the `main` deb as ephemeral, and allows us to ignore schema changes that are merged in from PRs